### PR TITLE
patch: Fix mountpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,23 @@
-FROM ubuntu:20.04
+FROM continuumio/miniconda3:v25.11.1
 LABEL name="quay.io/lifebitaiorg/rnatoy" \
       description="A docker container for rnatoy pipeline" \
       maintainer="David Pineyro <david.pineyro@lifebit.ai>"
 
-# Set environment variables to prevent interactive prompts
-ENV DEBIAN_FRONTEND=noninteractive
-# Add tools to PATH so they can be called directly
-ENV PATH=$PATH:/opt/bowtie2:/opt/tophat:/opt/cufflinks
+RUN conda config --add channels defaults && \
+    conda config --add channels bioconda && \
+    conda config --add channels conda-forge
 
-# 1. Install System Dependencies
-# 'procps' is required for Nextflow metrics
-# 'python2' is required for TopHat2
-# 'libncurses5' is required for older bio-binaries (TopHat/Cufflinks)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
-    unzip \
-    tar \
-    bzip2 \
-    ca-certificates \
-    build-essential \
-    zlib1g-dev \
-    libncurses5-dev \
-    libncurses5 \
-    samtools \
-    python2 \
-    procps \
-    && rm -rf /var/lib/apt/lists/*
+COPY environment.yml /
+ARG ENV_NAME="rnatoy"
+RUN conda env create -f environment.yml -n ${ENV_NAME} && \
+    conda clean -a
 
-# 2. Fix Python environment
-# TopHat expects 'python' to be Python 2
-RUN ln -s /usr/bin/python2 /usr/bin/python
+# Add conda installation dir to PATH
+ENV PATH /opt/conda/envs/${ENV_NAME}/bin:$PATH
 
-# 3. Install Bowtie2 (v2.2.7)
-WORKDIR /opt
-RUN wget -q -O bowtie.zip https://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.7/bowtie2-2.2.7-linux-x86_64.zip/download && \
-    unzip bowtie.zip -d /opt/ && \
-    mv /opt/bowtie2-2.2.7 /opt/bowtie2 && \
-    rm bowtie.zip
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name ${ENV_NAME} > ${ENV_NAME}_exported.yml
 
-# 4. Install Cufflinks (v2.2.1)
-RUN wget -q http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.2.1.Linux_x86_64.tar.gz -O- \
-    | tar xz -C /opt/ && \
-    mv /opt/cufflinks-2.2.1.Linux_x86_64 /opt/cufflinks
+CMD ["/bin/bash"]
 
-# 5. Install TopHat2 (v2.1.0)
-RUN wget -q https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.0.Linux_x86_64.tar.gz -O- \
-    | tar xz -C /opt/ && \
-    mv /opt/tophat-2.1.0.Linux_x86_64 /opt/tophat
-
-WORKDIR /data
+ENTRYPOINT [""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,51 @@
-FROM pditommaso/dkrbase:1.2
+FROM ubuntu:20.04
+LABEL name="quay.io/lifebitaiorg/rnatoy" \
+      description="A docker container for rnatoy pipeline" \
+      maintainer="David Pineyro <david.pineyro@lifebit.ai>"
 
-MAINTAINER Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+# Set environment variables to prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+# Add tools to PATH so they can be called directly
+ENV PATH=$PATH:/opt/bowtie2:/opt/tophat:/opt/cufflinks
 
-#
-# Install pre-requistes
-#
-RUN apt-get update --fix-missing && \
-  apt-get install -q -y samtools python 
-  
-#
-# RNA-Seq tools 
-# 
+# 1. Install System Dependencies
+# 'procps' is required for Nextflow metrics
+# 'python2' is required for TopHat2
+# 'libncurses5' is required for older bio-binaries (TopHat/Cufflinks)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    unzip \
+    tar \
+    bzip2 \
+    ca-certificates \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libncurses5 \
+    samtools \
+    python2 \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
 
+# 2. Fix Python environment
+# TopHat expects 'python' to be Python 2
+RUN ln -s /usr/bin/python2 /usr/bin/python
+
+# 3. Install Bowtie2 (v2.2.7)
+WORKDIR /opt
 RUN wget -q -O bowtie.zip https://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.7/bowtie2-2.2.7-linux-x86_64.zip/download && \
-  unzip bowtie.zip -d /opt/ && \
-  ln -s /opt/bowtie2-2.2.7/ /opt/bowtie && \
-  rm bowtie.zip 
-  
-RUN \
-  wget -q http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.2.1.Linux_x86_64.tar.gz -O- \
-  | tar xz -C /opt/ && \
-  ln -s /opt/cufflinks-2.2.1.Linux_x86_64/ /opt/cufflinks 
-  
-  
-RUN \
-  wget -q https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.0.Linux_x86_64.tar.gz -O- \
-  | tar xz -C /opt/ && \
-  ln -s /opt/tophat-2.1.0.Linux_x86_64/ /opt/tophat 
-  
-#
-# Finalize environment
-#
-ENV PATH=$PATH:/opt/bowtie:/opt/tophat:/opt/cufflinks
+    unzip bowtie.zip -d /opt/ && \
+    mv /opt/bowtie2-2.2.7 /opt/bowtie2 && \
+    rm bowtie.zip
+
+# 4. Install Cufflinks (v2.2.1)
+RUN wget -q http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.2.1.Linux_x86_64.tar.gz -O- \
+    | tar xz -C /opt/ && \
+    mv /opt/cufflinks-2.2.1.Linux_x86_64 /opt/cufflinks
+
+# 5. Install TopHat2 (v2.1.0)
+RUN wget -q https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.0.Linux_x86_64.tar.gz -O- \
+    | tar xz -C /opt/ && \
+    mv /opt/tophat-2.1.0.Linux_x86_64 /opt/tophat
+
+WORKDIR /data

--- a/conf/cloud-provider.config
+++ b/conf/cloud-provider.config
@@ -1,0 +1,40 @@
+if (params.lifebit_platform_executor == "local" || params.lifebit_platform_executor == "lsf" || params.lifebit_platform_executor == "slurm" || params.lifebit_platform_executor == "k8s") {
+  params {
+    reference_data_bucket = "s3://lifebit-featured-datasets"
+  }
+  includeConfig 'containers/quay.config' // public quay.io container registry
+}
+if (params.lifebit_platform_executor == "awsbatch" && params.lifebit_platform_deployment =~ "lifebit.ai") {
+  params {
+    reference_data_bucket = "s3://${params.lifebit_platform_cloud_region}-lb-featured-datasets"
+  }
+  includeConfig 'containers/quay.config' // TODO - Replace with ECR
+}
+if (params.lifebit_platform_executor == "awsbatch" && params.lifebit_platform_deployment =~ "cloudos.pro.synapxe.lifebit-biotech.com") {
+  params {
+    reference_data_bucket = "s3://${params.lifebit_platform_cloud_region}-lb-featured-datasets"
+    container_region = params.lifebit_platform_cloud_region
+  }
+  includeConfig 'containers/ecr.config' // private aws container registry
+}
+if (params.lifebit_platform_executor == "azurebatch" && params.lifebit_platform_deployment =~ "lifebit.ai") {
+  params {
+    reference_data_bucket = "s3://lifebit-featured-datasets"
+    container_region = params.lifebit_platform_cloud_region
+  }
+  includeConfig 'executors/azurebatch.config' // azure batch specific configuration
+  includeConfig 'containers/quay.config'
+}
+if (params.lifebit_platform_executor == "google" && params.lifebit_platform_deployment =~ "cloudos.lifebit.ai") {
+  params {
+    reference_data_bucket = "gc://${params.lifebit_platform_cloud_region}-lb-featured-datasets"
+    container_region = params.lifebit_platform_cloud_region
+  }
+  includeConfig 'containers/gcr.config' // private google container registry
+}
+if (params.lifebit_platform_executor == "awsbatch" && params.lifebit_platform_deployment =~ "aws.gel.ac") {
+  params {
+    reference_data_bucket = "s3://eu-west-2-lb-featured-datasets"
+  }
+  includeConfig 'containers/quay.config'
+}

--- a/conf/cloud-provider.config
+++ b/conf/cloud-provider.config
@@ -22,7 +22,6 @@ if (params.lifebit_platform_executor == "azurebatch" && params.lifebit_platform_
     reference_data_bucket = "s3://lifebit-featured-datasets"
     container_region = params.lifebit_platform_cloud_region
   }
-  includeConfig 'executors/azurebatch.config' // azure batch specific configuration
   includeConfig 'containers/quay.config'
 }
 if (params.lifebit_platform_executor == "google" && params.lifebit_platform_deployment =~ "cloudos.lifebit.ai") {
@@ -30,11 +29,11 @@ if (params.lifebit_platform_executor == "google" && params.lifebit_platform_depl
     reference_data_bucket = "gc://${params.lifebit_platform_cloud_region}-lb-featured-datasets"
     container_region = params.lifebit_platform_cloud_region
   }
-  includeConfig 'containers/gcr.config' // private google container registry
+  includeConfig 'containers/quay.config'
 }
 if (params.lifebit_platform_executor == "awsbatch" && params.lifebit_platform_deployment =~ "aws.gel.ac") {
   params {
-    reference_data_bucket = "s3://eu-west-2-lb-featured-datasets"
+    reference_data_bucket = "s3://${params.lifebit_platform_cloud_region}-lb-featured-datasets"
   }
   includeConfig 'containers/quay.config'
 }

--- a/conf/cloud-provider.config
+++ b/conf/cloud-provider.config
@@ -24,9 +24,9 @@ if (params.lifebit_platform_executor == "azurebatch" && params.lifebit_platform_
   }
   includeConfig 'containers/quay.config'
 }
-if (params.lifebit_platform_executor == "google" && params.lifebit_platform_deployment =~ "cloudos.lifebit.ai") {
+if (params.lifebit_platform_executor == "google" && params.lifebit_platform_deployment =~ "lifebit.ai") {
   params {
-    reference_data_bucket = "gc://${params.lifebit_platform_cloud_region}-lb-featured-datasets"
+    reference_data_bucket = "s3://lifebit-featured-datasets"
     container_region = params.lifebit_platform_cloud_region
   }
   includeConfig 'containers/quay.config'

--- a/conf/containers/ecr.config
+++ b/conf/containers/ecr.config
@@ -1,0 +1,3 @@
+params {
+    main_container = "518054667335.dkr.ecr.${params.container_region}.amazonaws.com/lifebitaiorg/rnatoy:1.0.0-fips"
+}

--- a/conf/containers/quay.config
+++ b/conf/containers/quay.config
@@ -1,0 +1,3 @@
+params {
+    main_container = 'quay.io/lifebitaiorg/rnatoy:1.0.0'
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,11 +1,11 @@
 params{
 
-    reads= "s3://lifebit-featured-datasets/pipelines/rnatoy-data"
+    reads= "${params.reference_data_bucket}/pipelines/rnatoy-data"
     readsExtension="fq"
     allReads="${params.reads}/*_{1,2}.${params.readsExtension}"
 
-    annot = "s3://lifebit-featured-datasets/pipelines/rnatoy-data/ggal_1_48850000_49020000.bed.gff"
-    genome = "s3://lifebit-featured-datasets/pipelines/rnatoy-data/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
+    annot = "${params.reference_data_bucket}/pipelines/rnatoy-data/ggal_1_48850000_49020000.bed.gff"
+    genome = "${params.reference_data_bucket}/pipelines/rnatoy-data/ggal_1_48850000_49020000.Ggal71.500bpflank.fa"
     outdir = 'results'
 
 }

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: rnatoy
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=2.7
+  - bowtie2=2.2.8
+  - tophat=2.1.0
+  - cufflinks=2.2.1
+  - samtools=1.3.1
+  - pip

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@ parameters {
 docker.enabled = true
 
 process {
-  container = 'nextflow/rnatoy@sha256:9ac0345b5851b2b20913cb4e6d469df77cf1232bafcadf8fd929535614a85c75'
+  container = 'quay.io/lifebitaiorg/rnatoy:1.0.0'
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,10 +18,6 @@ params {
 
 docker.enabled = true
 
-process {
-  container = params.main_container
-}
-
 includeConfig 'conf/cloud-provider.config'
 
 profiles {
@@ -30,4 +26,8 @@ profiles {
   local { includeConfig 'conf/local.config' }
   quay { includeConfig 'conf/containers/quay.config' }
   ecr { includeConfig 'conf/containers/ecr.config' }
+}
+
+process {
+  container = params.main_container
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,18 +2,32 @@ manifest {
   description = 'Proof of concept of a Rna-seq pipeline implemented with Nextflow' 
 }
 
-parameters {
- result_files_label = ""
+includeConfig 'conf/containers/quay.config'
+
+params {
+
+  result_files_label = ""
+
+  // multi region support - these parameters expected from to be provided from cloudos for system tools
+  reference_data_bucket         = "s3://lifebit-featured-datasets"
+  lifebit_platform_deployment   = "cloudos.lifebit.ai"
+  lifebit_platform_cloud_region = "eu-west-1" // for interpreting bucket path and container region
+  lifebit_platform_executor     = "local"
+  container_region              = params.lifebit_platform_cloud_region // only required incase of cloud provider container registry ecr/acr/gcr
 }
 
 docker.enabled = true
 
 process {
-  container = 'quay.io/lifebitaiorg/rnatoy:1.0.0'
+  container = params.main_container
 }
+
+includeConfig 'conf/cloud-provider.config'
 
 profiles {
   standard { includeConfig 'conf/aws.config' }
   test  { includeConfig 'conf/test.config' }
   local { includeConfig 'conf/local.config' }
+  quay { includeConfig 'conf/containers/quay.config' }
+  ecr { includeConfig 'conf/containers/ecr.config' }
 }


### PR DESCRIPTION
## Overview

The RNAtoy is really old and it does not work when the user activates "Accelerated file staging" (which is now the default for the Platform).
The problem was that the docker image (created by Nextflow team in the early Nextflow days) was not compatible with the requirements of AWS mountpoints, failing the staging fase of each job without error message.
The new docker image fixes the issue.

In addition, I've added also our internal conventions so the pipeline can run `test` profile in any workspace (Synapxe, GEL, FedPaaS) without any modification.

## Tests

### Old job failing when using "Accelerated File Staging"
https://cloudos.lifebit.ai/app/advanced-analytics/analyses/696e1bb27cce1bb9f88d154e
 
<img width="2657" height="1246" alt="Screenshot 2026-02-10 at 17 28 42" src="https://github.com/user-attachments/assets/794ed774-802a-4207-b481-223e251a3d9e" />

### Updated container (quay.io version)
https://cloudos.lifebit.ai/app/advanced-analytics/analyses/698b6a98a5b90cb75e263be0
<img width="2013" height="714" alt="Screenshot 2026-02-10 at 18 39 04" src="https://github.com/user-attachments/assets/6781f53f-e7a3-4c10-8b71-fb9307aefa46" />
<img width="2180" height="754" alt="Screenshot 2026-02-10 at 18 39 31" src="https://github.com/user-attachments/assets/56c79465-b623-4e00-b488-a82334fd5d74" />
<img width="2114" height="985" alt="Screenshot 2026-02-10 at 18 39 54" src="https://github.com/user-attachments/assets/5ba00b41-6cfc-4e09-911c-2fbe20048098" />



### Updated container (ecr fips version)
https://cloudos.lifebit.ai/app/advanced-analytics/analyses/698b6aa9fb638f447e789f93
<img width="1959" height="782" alt="Screenshot 2026-02-10 at 18 40 30" src="https://github.com/user-attachments/assets/6d0a79ae-e5f8-433b-a3ff-ccc130b173c1" />
<img width="2056" height="946" alt="Screenshot 2026-02-10 at 18 41 03" src="https://github.com/user-attachments/assets/253f33c6-2492-4e35-bada-a5e15b120be3" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the container build/runtime environment and the pipeline’s container/image selection logic across executors/regions, which can affect tool availability and job execution on different platforms.
> 
> **Overview**
> Replaces the legacy `rnatoy` Docker image build (manual apt/wget-installed tools) with a Miniconda-based image that creates a pinned conda env from `environment.yml`, updates `PATH`, and exports the resolved env for reproducibility.
> 
> Updates `nextflow.config` to drive `process.container` via a `params.main_container` selected from new config includes, and adds cloud/executor-aware configuration (`conf/cloud-provider.config`) to set `reference_data_bucket` and choose between Quay (`conf/containers/quay.config`) and an AWS ECR FIPS image (`conf/containers/ecr.config`). The `test` profile is adjusted to build all dataset paths from `params.reference_data_bucket` instead of hardcoding a single S3 bucket.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 199388d56d1af45fffead8f6b331a604826f1815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->