### PR TITLE
fix: mountpoint fixed by updated docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nxf_ver: ['19.10.0', '']
+        nxf_ver: ['22.10.8']
     steps:
       - uses: actions/checkout@v2
       - name: Install Nextflow
@@ -19,7 +19,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Pull docker image
         run: |
-          docker pull nextflow/rnatoy@sha256:9ac0345b5851b2b20913cb4e6d469df77cf1232bafcadf8fd929535614a85c75
+          docker pull quay.io/lifebitaiorg/rnatoy:1.0.0
       - name: Run pipeline with test data
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,23 @@
-FROM pditommaso/dkrbase:1.2
+FROM continuumio/miniconda3:v25.11.1
+LABEL name="quay.io/lifebitaiorg/rnatoy" \
+      description="A docker container for rnatoy pipeline" \
+      maintainer="David Pineyro <david.pineyro@lifebit.ai>"
 
-MAINTAINER Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+RUN conda config --add channels defaults && \
+    conda config --add channels bioconda && \
+    conda config --add channels conda-forge
 
-#
-# Install pre-requistes
-#
-RUN apt-get update --fix-missing && \
-  apt-get install -q -y samtools python 
-  
-#
-# RNA-Seq tools 
-# 
+COPY environment.yml /
+ARG ENV_NAME="rnatoy"
+RUN conda env create -f environment.yml -n ${ENV_NAME} && \
+    conda clean -a
 
-RUN wget -q -O bowtie.zip https://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.7/bowtie2-2.2.7-linux-x86_64.zip/download && \
-  unzip bowtie.zip -d /opt/ && \
-  ln -s /opt/bowtie2-2.2.7/ /opt/bowtie && \
-  rm bowtie.zip 
-  
-RUN \
-  wget -q http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.2.1.Linux_x86_64.tar.gz -O- \
-  | tar xz -C /opt/ && \
-  ln -s /opt/cufflinks-2.2.1.Linux_x86_64/ /opt/cufflinks 
-  
-  
-RUN \
-  wget -q https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.0.Linux_x86_64.tar.gz -O- \
-  | tar xz -C /opt/ && \
-  ln -s /opt/tophat-2.1.0.Linux_x86_64/ /opt/tophat 
-  
-#
-# Finalize environment
-#
-ENV PATH=$PATH:/opt/bowtie:/opt/tophat:/opt/cufflinks
+# Add conda installation dir to PATH
+ENV PATH /opt/conda/envs/${ENV_NAME}/bin:$PATH
+
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name ${ENV_NAME} > ${ENV_NAME}_exported.yml
+
+CMD ["/bin/bash"]
+
+ENTRYPOINT [""]

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: rnatoy
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=2.7
+  - bowtie2=2.2.8
+  - tophat=2.1.0
+  - cufflinks=2.2.1
+  - samtools=1.3.1
+  - pip

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@ parameters {
 docker.enabled = true
 
 process {
-  container = 'nextflow/rnatoy@sha256:9ac0345b5851b2b20913cb4e6d469df77cf1232bafcadf8fd929535614a85c75'
+  container = 'quay.io/lifebitaiorg/rnatoy:1.0.0'
 }
 
 profiles {


### PR DESCRIPTION
## Overview

The RNAtoy is really old and it does not work when the user activates "Accelerated file staging" (which is now the default for the Platform).
The problem is that the docker image (created by Nextflow team in the early Nextflow days) was not compatible with the requirements of AWS mountpoints, failing the staging fase of each job without error message.
The new docker image fixes the issue.


## Tests

### Old job failing when using "Accelerated File Staging" 🔴 
https://cloudos.lifebit.ai/app/advanced-analytics/analyses/696e1bb27cce1bb9f88d154e
 
<img width="2657" height="1246" alt="Screenshot 2026-02-10 at 17 28 42" src="https://github.com/user-attachments/assets/794ed774-802a-4207-b481-223e251a3d9e" />

### Updated container (quay.io version) 🟢 
https://cloudos.lifebit.ai/app/advanced-analytics/analyses/698dffad145991bf6b9eb253
<img width="2003" height="748" alt="Screenshot 2026-02-12 at 17 35 31" src="https://github.com/user-attachments/assets/e71ae512-bd5f-48c1-9efe-ade505a05f3d" />
<img width="2085" height="982" alt="Screenshot 2026-02-12 at 17 36 00" src="https://github.com/user-attachments/assets/c7d6f258-552e-4949-92d9-a5665838e421" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the execution container and tool installation method, which can affect pipeline runtime behavior and reproducibility. CI coverage is narrowed to a single Nextflow version, potentially missing version-specific regressions.
> 
> **Overview**
> Switches the pipeline runtime container from the legacy `nextflow/rnatoy@sha256...` image to `quay.io/lifebitaiorg/rnatoy:1.0.0` (in `nextflow.config` and CI), to address execution/staging compatibility issues.
> 
> Replaces the old apt/wget-based Docker build with a Miniconda-based image that creates a pinned conda environment from a new `environment.yml`, and updates GitHub Actions CI to test only on Nextflow `22.10.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb80793b9212d4e695f449026c1e2a887662fdf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->